### PR TITLE
[Add] Checking the Selected Medicine function

### DIFF
--- a/Jikyeojulge/Model/MedicineModel.swift
+++ b/Jikyeojulge/Model/MedicineModel.swift
@@ -22,7 +22,7 @@ struct MedicineModel: Codable {
     let items: [Medicine]?
 }
 
-struct Medicine: Codable {
+struct Medicine: Codable, Hashable {
     let entpName: String? // 업체명
     let itemName: String? // 제품명
     let itemSeq: String? // 품목기준코드

--- a/Jikyeojulge/UIComponent/MedicineInfo.swift
+++ b/Jikyeojulge/UIComponent/MedicineInfo.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct MedicineInfo: View {
+    @ObservedObject var networkManager: NetworkManager
     var medicine: Medicine
 
     var body: some View {
@@ -18,8 +19,17 @@ struct MedicineInfo: View {
                 .padding(.trailing, 16)
             
             VStack(alignment: .leading, spacing: 15) {
-                contentsProvider(contents: medicine.itemName)
-                    .font(.system(size: 16, weight: .bold))
+                HStack(alignment: .top) {
+                    contentsProvider(contents: medicine.itemName)
+                        .font(.system(size: 16, weight: .bold))
+                    
+                    Spacer()
+                    
+                    if networkManager.compareMedicine(medicine: medicine) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(Color.green)
+                    }
+                }
                 
                 contentsProvider(contents: medicine.efcyQesitm)
                     .font(.system(size: 14))

--- a/Jikyeojulge/View/MedicineRecordView.swift
+++ b/Jikyeojulge/View/MedicineRecordView.swift
@@ -94,7 +94,7 @@ struct MedicineRecordView: View {
                     Button(action: {
                         
                     }, label: {
-                        Text("확인")
+                        Text("조회")
                     })
                     .padding(7)
                     .foregroundColor(Color.white)

--- a/Jikyeojulge/View/MedicineSearchView.swift
+++ b/Jikyeojulge/View/MedicineSearchView.swift
@@ -23,11 +23,7 @@ struct MedicineSearchView: View {
                     .ignoresSafeArea()
                 List(networkManager.medicineList, id: \.itemSeq) { medicine in
                     Button(action: {
-                        if networkManager.compareMedicine(medicine: medicine) {
-                            networkManager.popMedicineSet(medicine: medicine)
-                        } else {
-                            networkManager.addMedicineSet(medicine: medicine)
-                        }
+                        networkManager.selectMedicine(medicine: medicine)
                     }, label: {
                         MedicineInfo(networkManager: networkManager, medicine: medicine)
                     })

--- a/Jikyeojulge/View/MedicineSearchView.swift
+++ b/Jikyeojulge/View/MedicineSearchView.swift
@@ -53,7 +53,7 @@ struct MedicineSearchView: View {
                     Button(action: {
                         presentationMode.wrappedValue.dismiss()
                     }, label: {
-                        Text("확인")
+                        Text("저장")
                     })
                 })
             }

--- a/Jikyeojulge/View/MedicineSearchView.swift
+++ b/Jikyeojulge/View/MedicineSearchView.swift
@@ -23,9 +23,13 @@ struct MedicineSearchView: View {
                     .ignoresSafeArea()
                 List(networkManager.medicineList, id: \.itemSeq) { medicine in
                     Button(action: {
-                        saveMedicine(medicine: medicine)
+                        if networkManager.compareMedicine(medicine: medicine) {
+                            networkManager.popMedicineSet(medicine: medicine)
+                        } else {
+                            networkManager.addMedicineSet(medicine: medicine)
+                        }
                     }, label: {
-                        MedicineInfo(medicine: medicine)
+                        MedicineInfo(networkManager: networkManager, medicine: medicine)
                     })
                     .foregroundColor(.black)
                 }
@@ -51,6 +55,7 @@ struct MedicineSearchView: View {
                 })
                 ToolbarItemGroup(placement: .navigationBarTrailing, content: {
                     Button(action: {
+                        saveMedicine(medicineList: networkManager.selectedMedicineSet)
                         presentationMode.wrappedValue.dismiss()
                     }, label: {
                         Text("저장")
@@ -64,17 +69,22 @@ struct MedicineSearchView: View {
         return contents?.replacingOccurrences(of: "<[^>]+>", with: "", options: String.CompareOptions.regularExpression, range: nil) ?? "등록된 정보가 없습니다"
     }
     
-    func saveMedicine(medicine: Medicine) {
-        let add = MedicineDataEntity(context: viewContext)
-        add.itemName = removeHTMLTag(contents: medicine.itemName)
-        add.itemSeq = removeHTMLTag(contents: medicine.itemSeq)
-        add.itemImage = medicine.itemImage
-        add.date = Date()
-        add.efcyQesitm = removeHTMLTag(contents: medicine.efcyQesitm)
-        add.intrcQesitm = removeHTMLTag(contents: medicine.intrcQesitm)
-        add.seQesitm = removeHTMLTag(contents: medicine.seQesitm)
-        
-        try! self.viewContext.save()
+    func saveMedicine(medicineList: Set<Medicine>) {
+        var medicineList = medicineList
+        while !medicineList.isEmpty {
+            let medicine = medicineList.popFirst()
+            
+            let add = MedicineDataEntity(context: viewContext)
+            add.itemName = removeHTMLTag(contents: medicine?.itemName)
+            add.itemSeq = removeHTMLTag(contents: medicine?.itemSeq)
+            add.itemImage = medicine?.itemImage
+            add.date = Date()
+            add.efcyQesitm = removeHTMLTag(contents: medicine?.efcyQesitm)
+            add.intrcQesitm = removeHTMLTag(contents: medicine?.intrcQesitm)
+            add.seQesitm = removeHTMLTag(contents: medicine?.seQesitm)
+
+            try! self.viewContext.save()
+        }
     }
 }
 

--- a/Jikyeojulge/View/MedicineSearchView.swift
+++ b/Jikyeojulge/View/MedicineSearchView.swift
@@ -43,7 +43,7 @@ struct MedicineSearchView: View {
             .searchable(text: $searchKeyword, placement: .navigationBarDrawer(displayMode: .always))
             .disableAutocorrection(true)
             .onSubmit(of: .search) {
-                networkManager.getData(itemName: searchKeyword, itemSeq: "")
+                networkManager.requestMedicineData(itemName: searchKeyword, itemSeq: "")
             }
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarLeading, content: {

--- a/Jikyeojulge/View/SettingView.swift
+++ b/Jikyeojulge/View/SettingView.swift
@@ -53,6 +53,9 @@ struct SettingView: View {
                 }
             }
             .listStyle(InsetGroupedListStyle())
+            .onAppear {
+                UITableView.appearance().backgroundColor = UIColor.clear
+            }
         }
     }
 }

--- a/Jikyeojulge/ViewModel/NetworkManager.swift
+++ b/Jikyeojulge/ViewModel/NetworkManager.swift
@@ -10,6 +10,8 @@ import Foundation
 
 class NetworkManager: ObservableObject {
     @Published var medicineList = [Medicine]()
+    @Published var selectedMedicineSet = Set<Medicine>()
+    
     let urlString = "http://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList"
     
     let serviceKey = "5HtxWM9+fExd03260y2ei9X4a4e9UwwI5vbxKNtkVT1YrNGfNrapFTrlqApqhO1rX9LcaHYXEeT8yR9MCyRhnw=="
@@ -46,5 +48,21 @@ class NetworkManager: ObservableObject {
                 print("\(error.localizedDescription)\n\(error)")
             }
         }.resume()
+    }
+    
+    func addMedicineSet(medicine: Medicine) {
+        selectedMedicineSet.insert(medicine)
+    }
+    
+    func popMedicineSet(medicine: Medicine) {
+        selectedMedicineSet.remove(medicine)
+    }
+    
+    func compareMedicine(medicine: Medicine) -> Bool {
+        if selectedMedicineSet.contains(medicine) {
+            return true
+        } else {
+            return false
+        }
     }
 }

--- a/Jikyeojulge/ViewModel/NetworkManager.swift
+++ b/Jikyeojulge/ViewModel/NetworkManager.swift
@@ -65,4 +65,12 @@ class NetworkManager: ObservableObject {
             return false
         }
     }
+    
+    func selectMedicine(medicine: Medicine) {
+        if compareMedicine(medicine: medicine) {
+            popMedicineSet(medicine: medicine)
+        } else {
+            addMedicineSet(medicine: medicine)
+        }
+    }
 }

--- a/Jikyeojulge/ViewModel/NetworkManager.swift
+++ b/Jikyeojulge/ViewModel/NetworkManager.swift
@@ -17,7 +17,7 @@ class NetworkManager: ObservableObject {
     let serviceKey = "5HtxWM9+fExd03260y2ei9X4a4e9UwwI5vbxKNtkVT1YrNGfNrapFTrlqApqhO1rX9LcaHYXEeT8yR9MCyRhnw=="
     let type = "json"
     
-    func getData(itemName: String, itemSeq: String) {
+    func requestMedicineData(itemName: String, itemSeq: String) {
         var urlComponents = URLComponents(string: urlString)
         var components = urlComponents
         let serviceKeyQuery = URLQueryItem(name: "serviceKey", value: serviceKey)

--- a/JikyeojulgeWidget/JikyeojulgeWidget.swift
+++ b/JikyeojulgeWidget/JikyeojulgeWidget.swift
@@ -70,8 +70,17 @@ struct JikyeojulgeSmallWidgetEntryView : View {
                 WidgetText(personalInfoType: personalInfo[0].contact2 ?? "010\n1234\n5678", size: 34)
                 
             case .bloodType:
-                WidgetText(personalInfoType: personalInfo[0].bloodType ?? "AB+", size: 50)
+                WidgetText(personalInfoType: personalInfo[0].bloodType ?? "AB+", size: setFontSizeByBloodType(bloodType: personalInfo[0].bloodType ?? "AB+"))
             }
+        }
+    }
+    
+    func setFontSizeByBloodType(bloodType: String) -> Int {
+        switch bloodType {
+        case "AB+", "AB-":
+            return 50
+        default:
+            return 70
         }
     }
 }
@@ -88,16 +97,34 @@ struct JikyeojulgeMediumWidgetEntryView : View {
         ZStack{
             Color.widgetBlue
             HStack {
-                
-                WidgetText(personalInfoType: personalInfo[0].bloodType ?? "AB+", size: 65)
+                WidgetText(personalInfoType: personalInfo[0].bloodType ?? "AB+", size: setFontSizeByBloodType(bloodType: personalInfo[0].bloodType ?? "AB+", infoType: "bloodType"))
                     .padding(.trailing, 10)
+                
                 VStack(alignment: .leading) {
+                    WidgetText(personalInfoType: personalInfo[0].contact1 ?? "010-1234-5678", size: setFontSizeByBloodType(bloodType: personalInfo[0].bloodType ?? "AB+", infoType: "contact1"))
                     
-                    WidgetText(personalInfoType: personalInfo[0].contact1 ?? "010-1234-5678", size: 18)
-                    
-                    WidgetText(personalInfoType: personalInfo[0].contact2 ?? "010-1234-5678", size: 18)
+                    WidgetText(personalInfoType: personalInfo[0].contact2 ?? "010-1234-5678", size: setFontSizeByBloodType(bloodType: personalInfo[0].bloodType ?? "AB+", infoType: "contact2"))
                         .padding(.top, 5)
                 }
+            }
+        }
+    }
+    
+    func setFontSizeByBloodType(bloodType: String, infoType: String) -> Int {
+        switch bloodType {
+        case "AB+", "AB-":
+            if infoType == "bloodType" {
+                return 65
+            }
+            else {
+                return 18
+            }
+        default:
+            if infoType == "bloodType" {
+                return 70
+            }
+            else {
+                return 22
             }
         }
     }


### PR DESCRIPTION
## 작업 내역
- 선택된 약 표시 기능 추가
  - `NetworkManager`에 `MedicineSearchView`에서 검색되어 선택된 약의 정보가 저장될 수 있는 `selectedMedicineSet` set를 추가했습니다.
  - `NetworkManager`에 `MedicineSearchView`에서 선택한 약의 정보가 저장될 수 있도록 하는 `addMedicineSet` function을 추가했습니다.
  - `NetworkManager`에 `MedicineSearchView`에서 선택된 약을 다시 선택했을 때, 약의 선택을 취소하는 `popMedicineSet` function을 추가했습니다.
  - `NetworkManager`에 `MedicineSearchView`에서 약이 선택되었는지 비교하는 `compareMedicine` function을 추가했습니다.
  - `MedicineInfo` View에 약이 선택되었을 때, 선택된 약을 표시해주는 아이콘을 추가했습니다.
  - `Medicine` structure에 set에서 사용 가능하도록 Hashable protocol을 추가했습니다.
  - `NetworkManager`에 `addMedicineSet` function과 `popMedicineSet` function을 엮은 `selectMedicine` function을 추가했습니다.
- 직관적이지 못한 이름 변경
  - `NetworkManager`에서 API에서 약의 정보를 가져오는 `getData` function의 이름을 `requestMedicineData`로 수정했습니다.
- 위젯 수정
  - 혈액형 별로 글자의 길이가 다른 것을 고려하여 `AB+`형, `AB-`형 일 때, 혈액형과 전화번호의 글자 크기를 변경하도록 수정했습니다.
- 그 외의 자잘한 수정
  - `SettingView`의 배경 색을 앱의 컬러와 같게 변경했습니다. 이는 임시적인 것으로 후에 원래되로 롤백시킬 예정입니다.
  - `MedicineRecordView`에서 날짜별 약 정보를 조회하는 버튼의 텍스트를 `확인`에서 `조회`로 수정했습니다.
  - `MedicineSearchView`에서 선택된 약의 정보를 저장하는 버튼의 텍스트를 `확인`에서 `저장`으로 수정했습니다.